### PR TITLE
fix(src-tauri): misspelling method on main.rs

### DIFF
--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -6,7 +6,7 @@
 )]
 
 use tauri::Manager;
-use window_vibrancy::{apply_acrylic, NSVisualEffectMaterial};
+use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
 
 fn main() {
     tauri::Builder::default()


### PR DESCRIPTION
<img width="600" alt="Error" src="https://github.com/pheralb/typethings/assets/49660697/548ed90f-ad16-4ff2-9a58-bcd19d493b95">

This error locks the startup on MacOS.
